### PR TITLE
fix: update glazewm workspaces on focus changes; order workspaces by number

### DIFF
--- a/packages/client-api/src/providers/glazewm/create-glazewm-provider.ts
+++ b/packages/client-api/src/providers/glazewm/create-glazewm-provider.ts
@@ -28,7 +28,11 @@ export async function createGlazewmProvider(
   await refetch();
 
   await client.subscribeMany(
-    [GwmEventType.WORKSPACE_ACTIVATED, GwmEventType.WORKSPACE_DEACTIVATED],
+    [
+      GwmEventType.WORKSPACE_ACTIVATED, 
+      GwmEventType.WORKSPACE_DEACTIVATED,
+      GwmEventType.FOCUS_CHANGED
+    ],
     refetch,
   );
 
@@ -44,7 +48,7 @@ export async function createGlazewmProvider(
         : b,
     );
 
-    setGlazewmVariables({ workspacesOnMonitor: monitor.children });
+    setGlazewmVariables({ workspacesOnMonitor: monitor.children.sort((a, b) => Number(a.name) - Number(b.name)) });
   }
 
   return {


### PR DESCRIPTION
Add FOCUS_CHANGED to subscribed events in create-glazewm-provider, which addresses active workspace not updating when navigating to other workspaces.

Sort workspaces by name numerically to organise workspaces in ascending order in bar when they have default/number names.

Fixes #30 