### PR TITLE
chore: upgrade Komorebi client to v0.1.26

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -29,3 +29,4 @@ yarn-error.log*
 
 # Turbo
 .turbo
+/.vs

--- a/packages/client-api/src/providers/komorebi/create-komorebi-provider.ts
+++ b/packages/client-api/src/providers/komorebi/create-komorebi-provider.ts
@@ -99,6 +99,7 @@ export type KomorebiLayout =
   | 'ultrawide_vertical_stack'
   | 'rows'
   | 'grid'
+  | 'right_main_vertical_stack'
   | 'custom';
 
 export type KomorebiLayoutFlip =

--- a/packages/desktop/Cargo.toml
+++ b/packages/desktop/Cargo.toml
@@ -33,7 +33,7 @@ netdev = "0.24"
 regex = "1"
 
 [target.'cfg(all(target_os = "windows", target_arch = "x86_64"))'.dependencies]
-komorebi-client = { git = "https://github.com/LGUG2Z/komorebi", tag = "v0.1.23" }
+komorebi-client = { git = "https://github.com/LGUG2Z/komorebi", tag = "v0.1.25" }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 cocoa = "0.25"

--- a/packages/desktop/Cargo.toml
+++ b/packages/desktop/Cargo.toml
@@ -33,7 +33,7 @@ netdev = "0.24"
 regex = "1"
 
 [target.'cfg(all(target_os = "windows", target_arch = "x86_64"))'.dependencies]
-komorebi-client = { git = "https://github.com/LGUG2Z/komorebi", tag = "v0.1.25" }
+komorebi-client = { git = "https://github.com/LGUG2Z/komorebi", tag = "v0.1.26" }
 
 [target.'cfg(target_os = "macos")'.dependencies]
 cocoa = "0.25"

--- a/packages/desktop/src/providers/komorebi/provider.rs
+++ b/packages/desktop/src/providers/komorebi/provider.rs
@@ -59,7 +59,7 @@ impl KomorebiProvider {
     KomorebiMonitor {
       id: monitor.id(),
       name: monitor.name().to_string(),
-      device_id: monitor.device_id().clone(),
+      device_id: Some(monitor.device_id().clone()),
       focused_workspace_index: monitor.focused_workspace_idx(),
       size: *monitor.size(),
       work_area_size: *monitor.work_area_size(),

--- a/packages/desktop/src/providers/komorebi/variables.rs
+++ b/packages/desktop/src/providers/komorebi/variables.rs
@@ -62,6 +62,7 @@ pub enum KomorebiLayout {
   UltrawideVerticalStack,
   Rows,
   Grid,
+  RightMainVerticalStack,
   Custom,
 }
 
@@ -78,6 +79,7 @@ impl From<Layout> for KomorebiLayout {
           KomorebiLayout::UltrawideVerticalStack
         }
         DefaultLayout::Grid => KomorebiLayout::Grid,
+        DefaultLayout::RightMainVerticalStack => KomorebiLayout::RightMainVerticalStack,
       },
       _ => KomorebiLayout::Custom,
     }


### PR DESCRIPTION
I intend to address an issue that is now fixed with Komorebi and Stackbar, as @LGUG2Z was kind enough to create a new release when this issue was fixed, just to make things faster.

This also helps those who upgrade Komorebi to a higher version compared to what is currently being used by Zebar, see #52. 