### PR TITLE
feat: toggle tiling direction on button click in sample config

### DIFF
--- a/packages/client-api/src/providers/glazewm/create-glazewm-provider.ts
+++ b/packages/client-api/src/providers/glazewm/create-glazewm-provider.ts
@@ -78,7 +78,7 @@ export interface GlazeWmProvider {
   focusWorkspace(name: string): void;
 
   /**
-   * Toggle tiling direction
+   * Toggle tiling direction.
    */
   toggleTilingDirection(): void;
 }

--- a/packages/client-api/src/providers/glazewm/create-glazewm-provider.ts
+++ b/packages/client-api/src/providers/glazewm/create-glazewm-provider.ts
@@ -76,6 +76,11 @@ export interface GlazeWmProvider {
    * Focus a workspace by name.
    */
   focusWorkspace(name: string): void;
+
+  /**
+   * Toggle tiling direction
+   */
+  toggleTilingDirection(): void;
 }
 
 export async function createGlazeWmProvider(
@@ -212,6 +217,10 @@ export async function createGlazeWmProvider(
     client.runCommand(`focus --workspace ${name}`);
   }
 
+  function toggleTilingDirection() {
+    client.runCommand('toggle-tiling-direction');
+  }
+
   return {
     get displayedWorkspace() {
       return glazeWmVariables.displayedWorkspace;
@@ -244,5 +253,6 @@ export async function createGlazeWmProvider(
       return glazeWmVariables.bindingModes;
     },
     focusWorkspace,
+    toggleTilingDirection,
   };
 }

--- a/packages/desktop/resources/sample-config.yaml
+++ b/packages/desktop/resources/sample-config.yaml
@@ -119,9 +119,6 @@ window/bar:
     template/glazewm_other:
       providers: ['glazewm']
       styles: |
-        display: flex;
-        gap: 5px;
-
         .binding-mode,
         .tiling-direction {
           background: rgb(255 255 255 / 15%);
@@ -130,10 +127,12 @@ window/bar:
           padding: 4px 6px;
           margin: 0;
         }
+
         .tiling-direction {
           border: 0;
           cursor: pointer;
         }
+
       events:
         - type: 'click'
           fn_path: 'script.js#toggleTilingDirection'

--- a/packages/desktop/resources/sample-config.yaml
+++ b/packages/desktop/resources/sample-config.yaml
@@ -110,6 +110,7 @@ window/bar:
     styles: |
       justify-self: end;
       display: flex;
+      align-items: center;
 
       .template {
         margin-left: 20px;
@@ -118,6 +119,9 @@ window/bar:
     template/glazewm_other:
       providers: ['glazewm']
       styles: |
+        display: flex;
+        gap: 5px;
+
         .binding-mode,
         .tiling-direction {
           background: rgb(255 255 255 / 15%);
@@ -126,7 +130,14 @@ window/bar:
           padding: 4px 6px;
           margin: 0;
         }
-
+        .tiling-direction {
+          border: 0;
+          cursor: pointer;
+        }
+      events:
+        - type: 'click'
+          fn_path: 'script.js#toggleTilingDirection'
+          selector: '.tiling-direction'
       template: |
         @for (bindingMode of glazewm.bindingModes) {
           <span class="binding-mode">
@@ -135,9 +146,9 @@ window/bar:
         }
 
         @if (glazewm.tilingDirection === 'horizontal') {
-          <i class="tiling-direction nf nf-md-swap_horizontal"></i>
+          <button class="tiling-direction nf nf-md-swap_horizontal"></button>
         } @else {
-          <i class="tiling-direction nf nf-md-swap_vertical"></i>
+          <button class="tiling-direction nf nf-md-swap_vertical"></button>
         }
 
     template/network:

--- a/packages/desktop/resources/script.js
+++ b/packages/desktop/resources/script.js
@@ -3,3 +3,8 @@ export function focusWorkspace(event, context) {
   const id = event.target.id;
   context.providers.glazewm.focusWorkspace(id);
 }
+
+export function toggleTilingDirection(event, context) {
+  console.log('Tiling direction toggled!', event, context);
+  context.providers.glazewm.toggleTilingDirection();
+}


### PR DESCRIPTION
The default config for Zebar contains an element that displays the tiling direction for glazewm. Added the `toggle-tiling-direction` command to the glazewm provider and made the button interactive in the sample config.