### PR TITLE
feat: Implement DOM reconciliation for templates

### DIFF
--- a/packages/client/package.json
+++ b/packages/client/package.json
@@ -8,6 +8,7 @@
     "wait:client-api": "wait-on ../client-api/dist/index.d.ts"
   },
   "dependencies": {
+    "morphdom": "2.7.4",
     "solid-js": "1.8.14",
     "zebar": "workspace:*"
   },

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -17,6 +17,9 @@ importers:
 
   packages/client:
     dependencies:
+      morphdom:
+        specifier: 2.7.4
+        version: 2.7.4
       solid-js:
         specifier: 1.8.14
         version: 1.8.14
@@ -1267,6 +1270,9 @@ packages:
   minipass@7.0.4:
     resolution: {integrity: sha512-jYofLM5Dam9279rdkWzqHozUo4ybjdZmCsDHePy5V/PbBcVMiSZR97gmAy45aqi8CK1lG2ECd356FU86avfwUQ==}
     engines: {node: '>=16 || 14 >=14.17'}
+
+  morphdom@2.7.4:
+    resolution: {integrity: sha512-ATTbWMgGa+FaMU3FhnFYB6WgulCqwf6opOll4CBzmVDTLvPMmUPrEv8CudmLPK0MESa64+6B89fWOxP3+YIlxQ==}
 
   ms@2.1.2:
     resolution: {integrity: sha512-sGkPx+VjMtmA6MX27oA4FBFELFCZZ4S4XqeGOXCv68tT+jb3vk/RyaKWP0PTKyWtmLSM0b+adUTEvbs1PEaH2w==}
@@ -2790,6 +2796,8 @@ snapshots:
   minimist@1.2.8: {}
 
   minipass@7.0.4: {}
+
+  morphdom@2.7.4: {}
 
   ms@2.1.2: {}
 


### PR DESCRIPTION
# Implement DOM reconciliation for templates

## The problem

Today, there's an issue with the logic around Zebar templates and how they are updated in the DOM. The current implementation replaces the `innerHTML` of the template node with the updated HTML from the templating engine.

This causes several issues, the most notable one being that it messes with CSS animations, which with the current implementation cannot have an "out"-animation for stuff like hover or classname toggling since the entire element is removed and re-inserted into the DOM - the "in" animation happens instead.

The solution to this, as well as a more efficient way to solve re-rendering of templates is DOM reconciliation and patching, meaning that only the operations that are needed for us to go from the original DOM tree to the desired DOM tree are performed.

Basic example where we in our template prints out the `cpu.usage` value from the `cpu` provider, and depending on the `cpu.usage` value we add different class names to the icon.:

```html
<!-- Current DOM -->
<div class="template" id="cpu">
  <i class="cpu-icon"></i>
  <span class="cpu-value">24%</span>
</div>

<!-- Desired DOM -->
<div class="template" id="cpu">
  <i class="cpu-icon high"></i>
  <span class="cpu-value">69%</span>
  <i class="cpu-warn></i>
</div>
```

If you imagine changes to the DOM like commits in git, the current change commit would look like this:

```diff
- <div class="template" id="cpu">
-   <i class="cpu-icon"></i>
-   <span class="cpu-value">24%</span>
- </div>
+ <div class="template" id="cpu">
+   <i class="cpu-icon high"></i>
+   <span class="cpu-value">69%</span>
+   <i class="cpu-warn></i>
+ </div>
```

We can see this if we observe the DOM in the devtools, the flashing nodes are the ones that are updated and we can see that even the nodes that don't have an update on them flash, meaning that everything is removed and re-inserted:

![zebardomdiff_before](https://github.com/user-attachments/assets/6e8decd8-a9b5-4d02-98b4-9f208e1eaba5)

The optimal scenario would be to compare the current DOM tree with the desired DOM tree with an algorithm that can calculate the minimum amount of operations possible (without just replacing everything) required on the old DOM to achieve the state of the desired DOM. Which, in our earlier scenario:

```html
<!-- Current DOM -->
<div class="template" id="cpu">
  <i class="cpu-icon"></i>
  <span class="cpu-value">24%</span>
</div>

<!-- Desired DOM -->
<div class="template" id="cpu">
  <i class="cpu-icon high"></i>
  <span class="cpu-value">69%</span>
  <i class="cpu-warn></i>
</div>
```

Would mean that these changes are required:
- The node for: `i.cpu-icon` should do `node.classList.add('high')`
- The node for `span.cpu-value` should do `node.textValue = newValue`
- The `i.cpu-warn` node is added at the end of the children of `div#cpu.template`, so a `node.appendChild(newNode)` is required.

## The solution

This PR utilizes a package called [`morphdom`](https://github.com/patrick-steele-idem/morphdom) that compares the trees of 2 nodes and calculates the correct operations needed and performs them recursively.

I also tried to use [`snabbdom`](https://github.com/snabbdom/snabbdom) which basically converts your DOM nodes to VirtualDOM first, does the calculations and then patches the DOM in the same manner as `morphdom` does. However, when I compared the time it took to perform updates, `morphdom` was **A LOT** faster. With regular template sizes the updates happen in 0.1-0.4ms, while `snabbdom` took several milliseconds. The VirtualDOM overhead seems unnecessary for now, and the performance is better so I went with `morphdom`. It's worth noting that the actual end result of both of them are the same.

So what does the same DOM update look like in this PR?

```diff
<div class="template" id="cpu">
-   <i class="cpu-icon"></i>
+   <i class="cpu-icon high"></i>
-   <span class="cpu-value">24%</span>
+   <span class="cpu-value">69%</span>
+   <i class="cpu-warn></i>
</div>
```

Sadly, markdown doesn't support just showing the parts of the line that is diffing from the removed line. But we can see that the outer div remains unchanged while the other values have updated as expected. It's much easier to spot the difference in the devtools:

![zebardomdiff_after](https://github.com/user-attachments/assets/134d670b-4de1-4c3a-9810-9fec0770c775)



