### PR TITLE
feat: added custom provider support

### DIFF
--- a/packages/client-api/src/providers/create-provider.ts
+++ b/packages/client-api/src/providers/create-provider.ts
@@ -2,6 +2,7 @@ import type { Owner } from 'solid-js';
 
 import { createBatteryProvider } from './battery/create-battery-provider';
 import { createCpuProvider } from './cpu/create-cpu-provider';
+import { createCustomProvider } from './custom/create-custom-provider';
 import { createDateProvider } from './date/create-date-provider';
 import { createGlazeWmProvider } from './glazewm/create-glazewm-provider';
 import { createHostProvider } from './host/create-host-provider';
@@ -30,6 +31,8 @@ export async function createProvider(
       return createBatteryProvider(config, owner);
     case ProviderType.CPU:
       return createCpuProvider(config, owner);
+    case ProviderType.CUSTOM:
+      return createCustomProvider(config, elementContext, owner);
     case ProviderType.DATE:
       return createDateProvider(config, owner);
     case ProviderType.GLAZEWM:

--- a/packages/client-api/src/providers/custom/create-custom-provider.ts
+++ b/packages/client-api/src/providers/custom/create-custom-provider.ts
@@ -1,0 +1,78 @@
+import {
+  createSignal,
+  onCleanup,
+  runWithOwner,
+  type Owner,
+} from 'solid-js';
+
+import type { ElementContext } from '~/index';
+import {
+  getScriptManager,
+  type CustomProviderConfig,
+} from '~/user-config';
+import type { PickPartial } from '~/utils';
+
+export interface CustomState {
+  state: unknown;
+}
+
+export async function createCustomProvider(
+  config: CustomProviderConfig,
+  elementContext: PickPartial<
+    ElementContext,
+    'parsedConfig' | 'providers'
+  >,
+  owner: Owner,
+): Promise<CustomState> {
+  const scriptManager = getScriptManager();
+
+  if (config.start_fn_path)
+    await scriptManager.callFn(
+      config.start_fn_path,
+      new Event('custom'),
+      elementContext,
+    );
+
+  const [state, setState] = createSignal<unknown>();
+
+  // run refresh fn first time to set initial state
+  setState(
+    await scriptManager.callFn(
+      config.refresh_fn_path,
+      new Event('custom'),
+      elementContext,
+    ),
+  );
+
+  // and then every refresh interval
+  const interval = setInterval(
+    async () =>
+      setState(
+        await scriptManager.callFn(
+          config.refresh_fn_path,
+          new Event('custom'),
+          elementContext,
+        ),
+      ),
+    config.refresh_interval,
+  );
+
+  runWithOwner(owner, () => {
+    onCleanup(async () => {
+      clearInterval(interval);
+
+      if (config.stop_fn_path)
+        await scriptManager.callFn(
+          config.stop_fn_path,
+          new Event('custom'),
+          elementContext,
+        );
+    });
+  });
+
+  return {
+    get state() {
+      return state();
+    },
+  };
+}

--- a/packages/client-api/src/providers/index.ts
+++ b/packages/client-api/src/providers/index.ts
@@ -1,5 +1,6 @@
 export * from './battery/create-battery-provider';
 export * from './cpu/create-cpu-provider';
+export * from './custom/create-custom-provider';
 export * from './date/create-date-provider';
 export * from './glazewm/create-glazewm-provider';
 export * from './ip/create-ip-provider';

--- a/packages/client-api/src/user-config/get-script-manager.ts
+++ b/packages/client-api/src/user-config/get-script-manager.ts
@@ -1,7 +1,7 @@
 import { convertFileSrc } from '@tauri-apps/api/core';
 import { join, homeDir } from '@tauri-apps/api/path';
 
-import { createLogger } from '~/utils';
+import { createLogger, type PickPartial } from '~/utils';
 import type { ElementContext } from '../element-context.model';
 
 const logger = createLogger('script-manager');
@@ -34,7 +34,7 @@ async function loadScriptForFn(fnPath: string): Promise<any> {
 async function callFn(
   fnPath: string,
   event: Event,
-  context: ElementContext,
+  context: PickPartial<ElementContext, 'parsedConfig' | 'providers'>,
 ): Promise<any> {
   const { modulePath, functionName } = parseFnPath(fnPath);
   const foundModule = await resolveModule(modulePath);

--- a/packages/client-api/src/user-config/shared/fn-path.ts
+++ b/packages/client-api/src/user-config/shared/fn-path.ts
@@ -1,0 +1,8 @@
+import { z } from 'zod';
+
+export const FnPathSchema = z
+  .string()
+  .regex(
+    /^(.+)#([a-zA-Z_$][a-zA-Z0-9_$]*)$/,
+    "Invalid function path. Needs to be in format 'path/to/my-script.js#functionName'.",
+  );

--- a/packages/client-api/src/user-config/shared/index.ts
+++ b/packages/client-api/src/user-config/shared/index.ts
@@ -1,3 +1,4 @@
 export * from './boolean-like.model';
+export * from './fn-path';
 export * from './get-child-configs';
 export * from './with-dynamic-key';

--- a/packages/client-api/src/user-config/window/element-events-config.model.ts
+++ b/packages/client-api/src/user-config/window/element-events-config.model.ts
@@ -1,4 +1,5 @@
 import { z } from 'zod';
+import { FnPathSchema } from '../shared';
 import type { Prettify } from '~/utils';
 
 /**
@@ -108,12 +109,7 @@ export const ElementEventsConfigSchema = z
   .array(
     z.object({
       type: z.enum(HTML_EVENTS),
-      fn_path: z
-        .string()
-        .regex(
-          /^(.+)#([a-zA-Z_$][a-zA-Z0-9_$]*)$/,
-          "Invalid function path. Needs to be in format 'path/to/my-script.js#functionName'.",
-        ),
+      fn_path: FnPathSchema,
       selector: z.string().optional(),
     }),
   )

--- a/packages/client-api/src/user-config/window/provider-config.model.ts
+++ b/packages/client-api/src/user-config/window/provider-config.model.ts
@@ -4,6 +4,7 @@ import type { Prettify } from '~/utils';
 import {
   BatteryProviderConfigSchema,
   CpuProviderConfigSchema,
+  CustomProviderConfigSchema,
   DateProviderConfigSchema,
   GlazeWmProviderConfigSchema,
   HostProviderConfigSchema,
@@ -20,6 +21,7 @@ import {
 export const ProviderConfigSchema = z.union([
   BatteryProviderConfigSchema,
   CpuProviderConfigSchema,
+  CustomProviderConfigSchema,
   DateProviderConfigSchema,
   GlazeWmProviderConfigSchema,
   HostProviderConfigSchema,

--- a/packages/client-api/src/user-config/window/provider-type.model.ts
+++ b/packages/client-api/src/user-config/window/provider-type.model.ts
@@ -3,6 +3,7 @@ import { z } from 'zod';
 export enum ProviderType {
   BATTERY = 'battery',
   CPU = 'cpu',
+  CUSTOM = 'custom',
   DATE = 'date',
   GLAZEWM = 'glazewm',
   HOST = 'host',

--- a/packages/client-api/src/user-config/window/providers/custom-provider.config.model.ts
+++ b/packages/client-api/src/user-config/window/providers/custom-provider.config.model.ts
@@ -3,13 +3,21 @@ import { z } from 'zod';
 import { ProviderType } from '../provider-type.model';
 import { FnPathSchema } from '~/user-config/shared';
 
-export const CustomProviderConfigSchema = z.object({
-  type: z.literal(ProviderType.CUSTOM),
-  refresh_interval: z.coerce.number().default(5 * 1000),
-  start_fn_path: FnPathSchema.optional(),
-  refresh_fn_path: FnPathSchema,
-  stop_fn_path: FnPathSchema.optional(),
-});
+export const CustomProviderConfigSchema = z.union([
+  z.object({
+    type: z.literal(ProviderType.CUSTOM),
+    refresh_interval: z.coerce.number().default(5 * 1000),
+    start_fn_path: FnPathSchema.optional(),
+    refresh_fn_path: FnPathSchema,
+    stop_fn_path: FnPathSchema.optional(),
+  }),
+  z.object({
+    type: z.literal(ProviderType.CUSTOM),
+    start_fn_path: FnPathSchema.optional(),
+    emitter_fn_path: FnPathSchema,
+    stop_fn_path: FnPathSchema.optional(),
+  }),
+]);
 
 export type CustomProviderConfig = z.infer<
   typeof CustomProviderConfigSchema

--- a/packages/client-api/src/user-config/window/providers/custom-provider.config.model.ts
+++ b/packages/client-api/src/user-config/window/providers/custom-provider.config.model.ts
@@ -1,0 +1,16 @@
+import { z } from 'zod';
+
+import { ProviderType } from '../provider-type.model';
+import { FnPathSchema } from '~/user-config/shared';
+
+export const CustomProviderConfigSchema = z.object({
+  type: z.literal(ProviderType.CUSTOM),
+  refresh_interval: z.coerce.number().default(5 * 1000),
+  start_fn_path: FnPathSchema.optional(),
+  refresh_fn_path: FnPathSchema,
+  stop_fn_path: FnPathSchema.optional(),
+});
+
+export type CustomProviderConfig = z.infer<
+  typeof CustomProviderConfigSchema
+>;

--- a/packages/client-api/src/user-config/window/providers/index.ts
+++ b/packages/client-api/src/user-config/window/providers/index.ts
@@ -1,5 +1,6 @@
 export * from './battery-provider-config.model';
 export * from './cpu-provider-config.model';
+export * from './custom-provider.config.model';
 export * from './date-provider-config.model';
 export * from './glazewm-provider-config.model';
 export * from './host-provider-config.model';

--- a/packages/client-api/src/utils/index.ts
+++ b/packages/client-api/src/utils/index.ts
@@ -5,5 +5,6 @@ export * from './create-getter-proxy';
 export * from './create-logger';
 export * from './create-string-scanner';
 export * from './get-coordinate-distance';
+export * from './is-event-target';
 export * from './simple-hash';
 export * from './to-css-selector';

--- a/packages/client-api/src/utils/is-event-target.ts
+++ b/packages/client-api/src/utils/is-event-target.ts
@@ -1,0 +1,3 @@
+export function isEventTarget(obj: any): obj is EventTarget {
+  return obj && typeof obj.addEventListener === 'function';
+}


### PR DESCRIPTION
This pull request includes new feature: custom provider.

Custom provider reads `refresh_fn_path` and optional `start_fn_path` or/and `stop_fn_path` scripts. Then runs `refresh_fn_path` function on interval defined via `refresh_interval` field and uses the return of that function as state.

You can access state via custom provider like that: `custom.state`.

## Example
template somewhere in config.yaml:
```YAML
    template/my-last-name:
      styles: |
        display: flex;
        align-items: center;
        flex-direction: column;
        color: var(--foreground-color);
        border: none;
        border-radius: 4px;
        background: none;

      providers: 
        - type: 'custom'
          refresh_fn_path: 'script.js#fetchMe'

      template: |
        <span>{{ custom.state.lastName }}</span>

```
Actual script:
```js
export async function fetchMe(event, context) {
      const res = await fetch('https://dummyjson.com/users/1', {
            method: 'GET',
      });

      return await res.json();
}
```

Partially closes #75