### PR TITLE
fix: fix `timezone` support of the date provider, closes #90

### DIFF
--- a/packages/client-api/src/providers/date/create-date-provider.ts
+++ b/packages/client-api/src/providers/date/create-date-provider.ts
@@ -51,10 +51,10 @@ export async function createDateProvider(
   }
 
   function toFormat(now: number, format: string) {
-    const dateTime = DateTime.fromMillis(now);
+    let dateTime = DateTime.fromMillis(now);
 
     if (config.timezone) {
-      dateTime.setZone(config.timezone);
+      dateTime = dateTime.setZone(config.timezone);
     }
 
     return dateTime.toFormat(format, { locale: config.locale });


### PR DESCRIPTION
The `timezone` config property wasn't applied correctly to the `timezone` property, ignoring the value of the `timezone` completely.

[Issue #90](https://github.com/glzr-io/zebar/issues/90)