### PR TITLE
fix: adjust window position for monitor DPI

### DIFF
--- a/packages/desktop/src/common/length_value.rs
+++ b/packages/desktop/src/common/length_value.rs
@@ -24,6 +24,13 @@ impl LengthValue {
       LengthUnit::Pixel => self.amount as i32,
     }
   }
+
+  pub fn to_px_scaled(&self, total_px: i32, scale_factor: f32) -> i32 {
+    match self.unit {
+      LengthUnit::Percentage => self.to_px(total_px),
+      LengthUnit::Pixel => (scale_factor * self.amount) as i32,
+    }
+  }
 }
 
 impl FromStr for LengthValue {

--- a/packages/desktop/src/widget_factory.rs
+++ b/packages/desktop/src/widget_factory.rs
@@ -233,7 +233,7 @@ impl WidgetFactory {
   async fn widget_placements(
     &self,
     config: &WidgetConfig,
-  ) -> Vec<(LogicalSize<f64>, LogicalPosition<f64>)> {
+  ) -> Vec<(PhysicalSize<f64>, PhysicalPosition<f64>)> {
     let mut placements = vec![];
 
     for placement in config.default_placements.iter() {
@@ -275,20 +275,30 @@ impl WidgetFactory {
           ),
         };
 
-        let size = LogicalSize::from_physical(
+        let size = {
+          let size = PhysicalSize::<f64>::from_logical(
+            LogicalSize::new(
+              placement.width.to_px(monitor.width as i32),
+              placement.height.to_px(monitor.height as i32),
+            ),
+            monitor.scale_factor,
+          );
           PhysicalSize::new(
-            placement.width.to_px(monitor.width as i32),
-            placement.height.to_px(monitor.height as i32),
+            f64::min(size.width, monitor.width as f64),
+            f64::min(size.height, monitor.height as f64),
+          )
+        };
+
+        let offset = PhysicalPosition::<f64>::from_logical(
+          LogicalPosition::new(
+            placement.offset_x.to_px(monitor.width as i32),
+            placement.offset_y.to_px(monitor.height as i32),
           ),
           monitor.scale_factor,
         );
-
-        let position = LogicalPosition::from_physical(
-          PhysicalPosition::new(
-            anchor_x + placement.offset_x.to_px(monitor.width as i32),
-            anchor_y + placement.offset_y.to_px(monitor.height as i32),
-          ),
-          monitor.scale_factor,
+        let position = PhysicalPosition::new(
+          anchor_x as f64 + offset.x,
+          anchor_y as f64 + offset.y,
         );
 
         placements.push((size, position));

--- a/packages/desktop/src/widget_factory.rs
+++ b/packages/desktop/src/widget_factory.rs
@@ -177,6 +177,9 @@ impl WidgetFactory {
       {
         let _ = window.set_size(size);
         let _ = window.set_position(position);
+        let _ = window.set_size(size);
+        // Is it also required to set the position twice or only the size?
+        let _ = window.set_position(position);
       }
 
       let mut widget_states = self.widget_states.lock().await;

--- a/packages/desktop/src/widget_factory.rs
+++ b/packages/desktop/src/widget_factory.rs
@@ -10,8 +10,8 @@ use std::{
 use anyhow::{bail, Context};
 use serde::Serialize;
 use tauri::{
-  AppHandle, LogicalPosition, LogicalSize, Manager, PhysicalPosition,
-  PhysicalSize, WebviewUrl, WebviewWindowBuilder, WindowEvent,
+  AppHandle, Manager, PhysicalPosition, PhysicalSize, WebviewUrl,
+  WebviewWindowBuilder, WindowEvent,
 };
 use tokio::{
   sync::{broadcast, Mutex},
@@ -278,30 +278,28 @@ impl WidgetFactory {
           ),
         };
 
-        let size = {
-          let size = PhysicalSize::<f64>::from_logical(
-            LogicalSize::new(
-              placement.width.to_px(monitor.width as i32),
-              placement.height.to_px(monitor.height as i32),
-            ),
-            monitor.scale_factor,
-          );
-          PhysicalSize::new(
-            f64::min(size.width, monitor.width as f64),
-            f64::min(size.height, monitor.height as f64),
-          )
-        };
-
-        let offset = PhysicalPosition::<f64>::from_logical(
-          LogicalPosition::new(
-            placement.offset_x.to_px(monitor.width as i32),
-            placement.offset_y.to_px(monitor.height as i32),
-          ),
-          monitor.scale_factor,
+        let width = placement
+          .width
+          .to_px_scaled(monitor.width as i32, monitor.scale_factor as f32);
+        let height = placement.height.to_px_scaled(
+          monitor.height as i32,
+          monitor.scale_factor as f32,
         );
-        let position = PhysicalPosition::new(
-          anchor_x as f64 + offset.x,
-          anchor_y as f64 + offset.y,
+        let size = PhysicalSize::<f64>::new(
+          i32::min(width, monitor.width as i32) as f64,
+          i32::min(height, monitor.height as i32) as f64,
+        );
+
+        let offset_x = placement
+          .offset_x
+          .to_px_scaled(monitor.width as i32, monitor.scale_factor as f32);
+        let offset_y = placement.offset_y.to_px_scaled(
+          monitor.height as i32,
+          monitor.scale_factor as f32,
+        );
+        let position = PhysicalPosition::<f64>::new(
+          (anchor_x + offset_x) as f64,
+          (anchor_y + offset_y) as f64,
         );
 
         placements.push((size, position));


### PR DESCRIPTION
1. Logical needs to be converted into Physical
2. `anchor_<x|y>` ([line 246](https://github.com/glzr-io/zebar/blob/badd5312c9e2e9ea2784bc63902cbd9ec1af4187/packages/desktop/src/widget_factory.rs#L246)) is already a PhysicalPosition 
# Example:
Monitor: 1600px 900px with 150%
```json
  "defaultPlacements": [
    {
      "anchor": "bottom_left",
      "offsetX": "0px",
      "offsetY": "-24px",
      "width": "100%",
      "height": "24px",
      "monitorSelection": {
        "type": "all"
      }
    }
  ]
```
Before the y-position was calculated by  `(1600+-24)*(2/3)` and not by `1600+(-24*(3/2))`.

I think that #115 might be related to this.