### PR TITLE
fix: hide overflow in examples

### DIFF
--- a/examples/boilerplate-react-buildless/styles.css
+++ b/examples/boilerplate-react-buildless/styles.css
@@ -2,6 +2,7 @@ body {
   color: rgb(255 255 255 / 90%);
   font-family: ui-monospace, monospace;
   font-size: 12px;
+  overflow: hidden;
 }
 
 html,

--- a/examples/boilerplate-solid-ts/src/index.css
+++ b/examples/boilerplate-solid-ts/src/index.css
@@ -2,6 +2,7 @@ body {
   color: rgb(255 255 255 / 90%);
   font-family: ui-monospace, monospace;
   font-size: 12px;
+  overflow: hidden;
 }
 
 html,

--- a/examples/starter/styles.css
+++ b/examples/starter/styles.css
@@ -13,6 +13,7 @@ body {
   color: rgb(255 255 255 / 90%);
   font-family: ui-monospace, monospace;
   font-size: 12px;
+  overflow: hidden;
 }
 
 html,


### PR DESCRIPTION
In the examples provided, add `overflow: hidden;` to avoid scrollbars on bar when overflowing.