### PR TITLE
feat: Load all windows and expose them via provider

### DIFF
--- a/README.md
+++ b/README.md
@@ -145,6 +145,7 @@ No config options.
 | `currentWorkspaces` | Workspaces on the current monitor.        | `Workspace[]` | <img src="https://github.com/glzr-io/zebar/assets/34844898/568e90c8-cd32-49a5-a17f-ab233d41f1aa" alt="microsoft icon" width="24"> |
 | `allWorkspaces` | Workspaces across all monitors.        | `Workspace[]` | <img src="https://github.com/glzr-io/zebar/assets/34844898/568e90c8-cd32-49a5-a17f-ab233d41f1aa" alt="microsoft icon" width="24"> |
 | `allMonitors` | All monitors.        | `Monitor[]` | <img src="https://github.com/glzr-io/zebar/assets/34844898/568e90c8-cd32-49a5-a17f-ab233d41f1aa" alt="microsoft icon" width="24"> |
+| `allWindows` | All windows.        | `Window[]` | <img src="https://github.com/glzr-io/zebar/assets/34844898/568e90c8-cd32-49a5-a17f-ab233d41f1aa" alt="microsoft icon" width="24"> |
 | `focusedMonitor` | Monitor that currently has focus.        | `Monitor` | <img src="https://github.com/glzr-io/zebar/assets/34844898/568e90c8-cd32-49a5-a17f-ab233d41f1aa" alt="microsoft icon" width="24"> |
 | `currentMonitor` | Monitor that is nearest to this Zebar widget.        | `Monitor` | <img src="https://github.com/glzr-io/zebar/assets/34844898/568e90c8-cd32-49a5-a17f-ab233d41f1aa" alt="microsoft icon" width="24"> |
 | `focusedContainer` | Container that currently has focus (on any monitor).        | `Container` | <img src="https://github.com/glzr-io/zebar/assets/34844898/568e90c8-cd32-49a5-a17f-ab233d41f1aa" alt="microsoft icon" width="24"> |

--- a/packages/client-api/src/providers/glazewm/create-glazewm-provider.ts
+++ b/packages/client-api/src/providers/glazewm/create-glazewm-provider.ts
@@ -134,6 +134,7 @@ export function createGlazeWmProvider(
         };
 
         const { monitors: glazeWmMonitors } = await client.queryMonitors();
+        const { windows: glazeWmWindows } = await client.queryWindows();
 
         // Get GlazeWM monitor that corresponds to the widget's monitor.
         const currentGlazeWmMonitor = glazeWmMonitors.reduce((a, b) =>
@@ -169,6 +170,7 @@ export function createGlazeWmProvider(
           focusedMonitor: focusedGlazeWmMonitor!,
           currentMonitor: currentGlazeWmMonitor,
           allMonitors: glazeWmMonitors,
+          allWindows: glazeWmWindows,
         };
       }
     });

--- a/packages/client-api/src/providers/glazewm/glazewm-provider-types.ts
+++ b/packages/client-api/src/providers/glazewm/glazewm-provider-types.ts
@@ -45,6 +45,11 @@ export interface GlazeWmOutput {
   allMonitors: Monitor[];
 
   /**
+   * All windows.
+   */
+  allWindows: Window[];
+
+  /**
    * Monitor that currently has focus.
    */
   focusedMonitor: Monitor;


### PR DESCRIPTION
Adds `allWindows` to the `glazewm` provider rather than having to traverse over allWorkspaces to find a specific window. I leveraged code that was already there to fetch the windows, and for now I fetch them whenever the monitor state was being fetched.

![image](https://github.com/user-attachments/assets/69c27ab2-0d88-4e12-93c1-01b7dacb7e7d)
