### PR TITLE
feat: add binding mode toggle to example glazewm config

### DIFF
--- a/examples/starter/with-glazewm.html
+++ b/examples/starter/with-glazewm.html
@@ -155,6 +155,7 @@
                     <button
                       className="binding-mode"
                       key={bindingMode.name}
+                      onClick={() => output.glazewm.runCommand(`wm-disable-binding-mode --name ${bindingMode.name}`)}
                     >
                       {bindingMode.displayName ?? bindingMode.name}
                     </button>


### PR DESCRIPTION
Using the glazewm example config, one can now click on the binding mode button to disable the mode again.

This is very useful, if a binding mode was not set correctly and there is no way to disable this (or you just forgot the shortcut).
