### PR TITLE
chore: add `dev:local` npm command

### DIFF
--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -20,7 +20,6 @@ pnpm i
 # Start in development mode. (config: /zebar/examples/)
 pnpm dev
 
-
 # Start in development mode. (config: ~/.glz/zebar/)
 pnpm dev:local
 ```

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -17,8 +17,12 @@ npm i -g pnpm
 # Install dependencies.
 pnpm i
 
-# Start in development mode.
+# Start in development mode. (config: /zebar/examples/)
 pnpm dev
+
+
+# Start in development mode. (config: ~/.glz/zebar/)
+pnpm dev:local
 ```
 
 After making your changes, push to your fork and [submit a pull request](https://github.com/glzr-io/zebar/pulls). Please try to address only a single feature or fix in the PR so that it's easy to review.

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "scripts": {
     "build": "pnpm run -r build",
     "dev": "pnpm run --filter zebar build && pnpm run --parallel dev",
+    "dev:local": "pnpm run --filter zebar build && pnpm run --parallel dev:local",
     "format": "prettier --write . && pnpm run -r format",
     "lint": "prettier --check . && pnpm run -r lint"
   },

--- a/packages/client-api/package.json
+++ b/packages/client-api/package.json
@@ -22,6 +22,7 @@
   "scripts": {
     "build": "tsup src/index.ts --format esm --dts",
     "dev": "npm run build -- --watch src",
+    "dev:local": "npm run build -- --watch src",
     "prepublishOnly": "npm run build"
   },
   "dependencies": {

--- a/packages/desktop/package.json
+++ b/packages/desktop/package.json
@@ -4,6 +4,7 @@
   "scripts": {
     "build": "npm run tauri build -- --verbose",
     "dev": "npm run tauri dev -- -- -- startup --config-dir=../../examples",
+    "dev:local": "npm run tauri dev -- -- -- startup",
     "format": "cargo fmt",
     "lint": "cargo fmt --check",
     "tauri": "tauri"

--- a/packages/settings-ui/package.json
+++ b/packages/settings-ui/package.json
@@ -4,7 +4,8 @@
   "description": "",
   "scripts": {
     "build": "vite build",
-    "dev": "vite"
+    "dev": "vite",
+    "dev:local": "vite"
   },
   "dependencies": {
     "@glzr/components": "1.0.2",


### PR DESCRIPTION
Adds `pnpm dev:local`.  Uses local config instead of `/examples/` config.