### PR TITLE
fix: stale layout values for keyboard provider

### DIFF
--- a/packages/desktop/src/main.rs
+++ b/packages/desktop/src/main.rs
@@ -252,7 +252,7 @@ fn listen_events(
         },
         Some(provider_emission) = emit_rx.recv() => {
           info!("Provider emission: {:?}", provider_emission);
-          app_handle.emit("provider-emit", provider_emission.clone());
+          let _ = app_handle.emit("provider-emit", provider_emission.clone());
           manager.update_cache(provider_emission).await;
           Ok(())
         },

--- a/packages/desktop/src/providers/keyboard/keyboard_provider.rs
+++ b/packages/desktop/src/providers/keyboard/keyboard_provider.rs
@@ -1,11 +1,14 @@
 use anyhow::bail;
 use serde::{Deserialize, Serialize};
 use windows::Win32::{
+  Foundation::{GetLastError, BOOL, HWND},
   Globalization::{LCIDToLocaleName, LOCALE_ALLOW_NEUTRAL_NAMES},
   System::SystemServices::LOCALE_NAME_MAX_LENGTH,
   UI::{
     Input::KeyboardAndMouse::GetKeyboardLayout,
-    WindowsAndMessaging::{GetForegroundWindow, GetWindowThreadProcessId},
+    WindowsAndMessaging::{
+      GetGUIThreadInfo, GetWindowThreadProcessId, GUITHREADINFO,
+    },
   },
 };
 
@@ -41,12 +44,21 @@ impl KeyboardProvider {
     KeyboardProvider { config, common }
   }
 
+  unsafe fn get_focused_hwnd() -> anyhow::Result<HWND> {
+    // see: https://stackoverflow.com/questions/51945835/how-to-obtain-keyboard-layout-for-microsoft-edge-and-other-windows-hosted-in-app
+    let mut gui_thread_info = GUITHREADINFO {
+      cbSize: std::mem::size_of::<GUITHREADINFO>() as u32,
+      ..Default::default()
+    };
+
+    GetGUIThreadInfo(0, &mut gui_thread_info)?;
+    return Ok(gui_thread_info.hwndFocus);
+  }
+
   fn run_interval(&mut self) -> anyhow::Result<KeyboardOutput> {
     let keyboard_layout = unsafe {
-      GetKeyboardLayout(GetWindowThreadProcessId(
-        GetForegroundWindow(),
-        None,
-      ))
+      let hwnd = KeyboardProvider::get_focused_hwnd()?;
+      GetKeyboardLayout(GetWindowThreadProcessId(hwnd, None))
     };
 
     let lang_id = (keyboard_layout.0 as u32) & 0xffff;

--- a/packages/desktop/src/providers/keyboard/keyboard_provider.rs
+++ b/packages/desktop/src/providers/keyboard/keyboard_provider.rs
@@ -1,7 +1,7 @@
 use anyhow::bail;
 use serde::{Deserialize, Serialize};
 use windows::Win32::{
-  Foundation::{GetLastError, BOOL, HWND},
+  Foundation::HWND,
   Globalization::{LCIDToLocaleName, LOCALE_ALLOW_NEUTRAL_NAMES},
   System::SystemServices::LOCALE_NAME_MAX_LENGTH,
   UI::{

--- a/packages/desktop/src/sys_tray.rs
+++ b/packages/desktop/src/sys_tray.rs
@@ -168,8 +168,9 @@ impl SysTray {
     // Show the settings window on left click (Windows-only).
     #[cfg(windows)]
     {
-      tray_icon =
-        tray_icon.menu_on_left_click(false).on_tray_icon_event({
+      tray_icon = tray_icon
+        .show_menu_on_left_click(false)
+        .on_tray_icon_event({
           let app_handle = self.app_handle.clone();
           let config = self.config.clone();
           let widget_factory = self.widget_factory.clone();


### PR DESCRIPTION
<!--
Before submitting a PR, follow this checklist:

1. Give the PR a descriptive title.

  Examples of good titles:
    - fix: fix race condition in message loop
    - docs: update readme with new demo gif
    - feat: add new `general.focus_follows_mouse` config option

  Examples of bad titles:
    - fix #7123
    - update docs
    - fix bugs

2. If there is a related issue, reference it in the PR description, e.g. closes #123.
3. Propose your changes as a draft PR if your work is still in progress.
-->

Attempts to fix keyboard provider showing stale values occasionally.