### PR TITLE
fix: handle transparency in mask-based icons for systray provider

### DIFF
--- a/crates/systray-util/src/util.rs
+++ b/crates/systray-util/src/util.rs
@@ -234,7 +234,7 @@ impl Util {
         if mask_alpha == 255 {
           // Make pixel transparent.
           chunk[3] = 0;
-        } else if chunk[0] != 0 || chunk[1] != 0 || chunk[2] != 0 {
+        } else {
           // Make pixel solid.
           chunk[3] = 255;
         }


### PR DESCRIPTION
Noticed there's an issue with transparency handling of old-school mask-based icons if there is a full black color involved.
In the original code if all the color channels are 0 (full black) it was treated as transparent which is incorrect.
I feel like removing this check will be a better option since we already establishing that we are dealing with mask-based icons beforehand with another check and there's only two possible values for those pixels - fully transparent (255) or opaque (everything else).

Before:
![4Dmo1qGeoR](https://github.com/user-attachments/assets/1088dd11-5191-4f98-9f44-72e515ca128f)

After:
![kUN3GF2uty](https://github.com/user-attachments/assets/d3a8ea5e-cbd4-4bca-9777-6d095098ec7d)

Windows systray:
![image](https://github.com/user-attachments/assets/ffff7f9f-b973-43f2-949a-471b75eeecef)

