### PR TITLE
fix: network icon functionality with proprietary vpn clients

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -2863,12 +2863,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "memalloc"
-version = "0.1.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "df39d232f5c40b0891c10216992c2f250c054105cb1e56f0fc9032db6203ecc1"
-
-[[package]]
 name = "memchr"
 version = "2.7.4"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3004,19 +2998,19 @@ dependencies = [
 
 [[package]]
 name = "netdev"
-version = "0.24.0"
+version = "0.33.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "3cb81882c2170b1d7594eb8c9c806e29eb831a4d6be829aea01ccfd26f13f496"
+checksum = "ccc812280a9201cb442e008d63d90933612ca7df8c0d4b49cc1825b383ba0add"
 dependencies = [
  "dlopen2 0.5.0",
+ "ipnet",
  "libc",
- "memalloc",
  "netlink-packet-core",
  "netlink-packet-route",
  "netlink-sys",
  "once_cell",
  "system-configuration 0.6.1",
- "windows 0.52.0",
+ "windows-sys 0.59.0",
 ]
 
 [[package]]
@@ -3032,14 +3026,15 @@ dependencies = [
 
 [[package]]
 name = "netlink-packet-route"
-version = "0.17.1"
+version = "0.21.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "053998cea5a306971f88580d0829e90f270f940befd7cf928da179d4187a5a66"
+checksum = "483325d4bfef65699214858f097d504eb812c38ce7077d165f301ec406c3066e"
 dependencies = [
  "anyhow",
- "bitflags 1.3.2",
+ "bitflags 2.8.0",
  "byteorder",
  "libc",
+ "log",
  "netlink-packet-core",
  "netlink-packet-utils",
 ]

--- a/examples/starter/vanilla.html
+++ b/examples/starter/vanilla.html
@@ -48,6 +48,8 @@
           switch (networkOutput.defaultInterface?.type) {
             case 'ethernet':
               return <i className="nf nf-md-ethernet_cable"></i>;
+            case 'proprietary_virtual':
+              return <i className="nf nf-md-shield_lock_outline"></i>;
             case 'wifi':
               if (networkOutput.defaultGateway?.signalStrength >= 80) {
                 return <i className="nf nf-md-wifi_strength_4"></i>;

--- a/examples/starter/with-glazewm.html
+++ b/examples/starter/with-glazewm.html
@@ -49,6 +49,8 @@
           switch (networkOutput.defaultInterface?.type) {
             case 'ethernet':
               return <i className="nf nf-md-ethernet_cable"></i>;
+            case 'proprietary_virtual':
+              return <i className="nf nf-md-shield_lock_outline"></i>;
             case 'wifi':
               if (networkOutput.defaultGateway?.signalStrength >= 80) {
                 return <i className="nf nf-md-wifi_strength_4"></i>;

--- a/examples/starter/with-komorebi.html
+++ b/examples/starter/with-komorebi.html
@@ -49,6 +49,8 @@
           switch (networkOutput.defaultInterface?.type) {
             case 'ethernet':
               return <i className="nf nf-md-ethernet_cable"></i>;
+            case 'proprietary_virtual':
+              return <i className="nf nf-md-shield_lock_outline"></i>;
             case 'wifi':
               if (networkOutput.defaultGateway?.signalStrength >= 80) {
                 return <i className="nf nf-md-wifi_strength_4"></i>;

--- a/packages/client-api/src/providers/network/network-provider-types.ts
+++ b/packages/client-api/src/providers/network/network-provider-types.ts
@@ -54,13 +54,15 @@ export type InterfaceType =
   | 'slip'
   | 'atm'
   | 'generic_modem'
+  | 'proprietary_virtual'
   | 'isdn'
   | 'wifi'
   | 'dsl'
   | 'tunnel'
   | 'high_performance_serial_bus'
   | 'mobile_broadband'
-  | 'bridge';
+  | 'bridge'
+  | 'can';
 
 export interface NetworkTraffic {
   received: DataSizeMeasure;

--- a/packages/desktop/Cargo.toml
+++ b/packages/desktop/Cargo.toml
@@ -18,7 +18,7 @@ async-trait = "0.1"
 base64 = "0.22"
 clap = { version = "4", features = ["derive"] }
 crossbeam = "0.8"
-netdev = "0.24"
+netdev = "0.33.0"
 regex = "1"
 reqwest = { version = "0.11", features = ["json"] }
 rocket = { version = "0.5", features = ["json"] }

--- a/packages/desktop/src/providers/network/netdev_res.rs
+++ b/packages/desktop/src/providers/network/netdev_res.rs
@@ -59,6 +59,7 @@ pub enum InterfaceType {
   Slip,
   Atm,
   GenericModem,
+  ProprietaryVirtual,
   Isdn,
   Wifi,
   Dsl,
@@ -66,6 +67,7 @@ pub enum InterfaceType {
   HighPerformanceSerialBus,
   MobileBroadband,
   Bridge,
+  Can,
 }
 
 impl From<NdInterfaceType> for InterfaceType {
@@ -86,6 +88,7 @@ impl From<NdInterfaceType> for InterfaceType {
         InterfaceType::Atm
       }
       NdInterfaceType::GenericModem => InterfaceType::GenericModem,
+      NdInterfaceType::ProprietaryVirtual => InterfaceType::ProprietaryVirtual,
       NdInterfaceType::Isdn
       | NdInterfaceType::BasicIsdn
       | NdInterfaceType::PrimaryIsdn => InterfaceType::Isdn,
@@ -103,6 +106,8 @@ impl From<NdInterfaceType> for InterfaceType {
       | NdInterfaceType::Wwanpp
       | NdInterfaceType::Wwanpp2 => InterfaceType::MobileBroadband,
       NdInterfaceType::Bridge => InterfaceType::Bridge,
+      NdInterfaceType::Can => InterfaceType::Can,
+      NdInterfaceType::UnknownWithValue(_u32) => InterfaceType::Unknown,
     }
   }
 }


### PR DESCRIPTION
1. fixed display of network icon when connected to a proprietary VPN such as Proton VPN, now default displays lock shield icon from nerd fonts and updated netdev dependency to version 0.33

![zebar_network_icon_fix](https://github.com/user-attachments/assets/25201a1c-bd99-42af-ad8c-375477836150)

2. i updated the 3 examples/starter html files also to add the vpn icon functionality to the examples. 

3. this addresses issue #199 and potentially #159.

4. i did not see any other additional errors or warnings after making these adjustments and confirmed that the other network icons are still functional.

5. this is my first PR ever, so feedback is welcomed. thank you to the team that created zebar and glazewm, they are both awesome!

