### PR TITLE
fix: adds GlazeWmOutput.isPaused

### DIFF
--- a/packages/client-api/src/providers/glazewm/glazewm-provider-types.ts
+++ b/packages/client-api/src/providers/glazewm/glazewm-provider-types.ts
@@ -76,6 +76,11 @@ export interface GlazeWmOutput {
   bindingModes: BindingModeConfig[];
 
   /**
+   * Whether GlazeWM is paused or not
+   */
+  isPaused: boolean
+
+  /**
    * Invokes a WM command (e.g. `"focus --workspace 1"`).
    *
    * @param command WM command to run (e.g. `"focus --workspace 1"`).


### PR DESCRIPTION
Adds the isPaused property to the GlazeWmOutput interface. The property can be accessed without it during runtime, but TypeScript throws missing typing errors without it therefore causing linting and intellisense issues.
