### PR TITLE
feat: add `isMuted` state and `setMute` to audio provider

### DIFF
--- a/packages/client-api/src/desktop/desktop-commands.ts
+++ b/packages/client-api/src/desktop/desktop-commands.ts
@@ -31,9 +31,10 @@ export type ProviderFunction =
 export interface AudioFunction {
   type: 'audio';
   function: {
-    name: 'set_volume';
+    name: 'set_volume' | 'set_mute';
     args: {
-      volume: number;
+      volume?: number;
+      mute?: boolean;
       deviceId?: string;
     };
   };

--- a/packages/client-api/src/providers/audio/audio-provider-types.ts
+++ b/packages/client-api/src/providers/audio/audio-provider-types.ts
@@ -12,6 +12,7 @@ export interface AudioOutput {
   playbackDevices: AudioDevice[];
   recordingDevices: AudioDevice[];
   setVolume(volume: number, options?: SetVolumeOptions): Promise<void>;
+  setMute(mute: boolean): Promise<void>;
 }
 
 export interface SetVolumeOptions {
@@ -25,6 +26,7 @@ export interface AudioDevice {
   type: AudioDeviceType;
   isDefaultPlayback: boolean;
   isDefaultRecording: boolean;
+  isMuted: boolean;
 }
 
 export type AudioDeviceType = 'playback' | 'recording';

--- a/packages/client-api/src/providers/audio/create-audio-provider.ts
+++ b/packages/client-api/src/providers/audio/create-audio-provider.ts
@@ -36,6 +36,15 @@ export function createAudioProvider(
                 },
               });
             },
+            setMute: (mute: boolean) => {
+              return desktopCommands.callProviderFunction(configHash, {
+                type: 'audio',
+                function: {
+                  name: 'set_mute',
+                  args: { mute },
+                }
+              });
+            }
           });
         }
       },

--- a/packages/desktop/src/providers/provider_function.rs
+++ b/packages/desktop/src/providers/provider_function.rs
@@ -12,11 +12,18 @@ pub enum ProviderFunction {
 #[serde(tag = "name", content = "args", rename_all = "snake_case")]
 pub enum AudioFunction {
   SetVolume(SetVolumeArgs),
+  SetMute(SetMuteArgs),
 }
 
 #[derive(Debug, Clone, Serialize, Deserialize)]
 pub struct SetVolumeArgs {
   pub volume: f32,
+  pub device_id: Option<String>,
+}
+
+#[derive(Debug, Clone, Serialize, Deserialize)]
+pub struct SetMuteArgs{
+  pub mute: bool,
   pub device_id: Option<String>,
 }
 


### PR DESCRIPTION
Audio provider currently does not provide a way to mute, which is bugged behaviour since a volume of 0 is still audible. This PR addresses https://github.com/glzr-io/zebar/issues/179.