### PR TITLE
feat: add auto dark/light theme support to starter config via `prefers-color-scheme`

### DIFF
--- a/examples/starter/styles.css
+++ b/examples/starter/styles.css
@@ -3,16 +3,40 @@
  * Ref https://www.nerdfonts.com/cheat-sheet for a cheatsheet of available Nerdfonts icons.
  */
 @import 'https://www.nerdfonts.com/assets/css/webfont.css';
+:root {
+  --text-size: 12px;
+  --icon-size: 12px; 
+  
+  --text-color-light: rgba(0 0 0 / 95%);
+  --text-color-dark: rgba(255 255 255 / 95%);
+  
+  --icon-color-light: LightSteelBlue; 
+  --icon-color-dark: rgba(115 130 175 / 95%);  
+
+  --background-color-light: rgba(238 238 238, 90%);
+  --background-color-dark: linear-gradient(rgb(0 0 0 / 90%), rgb(5 2 20 / 85%));
+}
+
+@media (prefers-color-scheme: light) { 
+body {color: var(--text-color-light);}
+i {color: var(--icon-color-light);} 
+#root {background: var(--background-color-light);}
+}
+
+@media (prefers-color-scheme: dark) { 
+body {color: var(--text-color-dark);}
+i {color: var(--icon-color-dark);} 
+#root {background: var(--background-color-dark);}
+}
 
 i {
-  color: rgb(115 130 175 / 95%);
   margin-right: 7px;
+  font-size: var(--icon-size);
 }
 
 body {
-  color: rgb(255 255 255 / 90%);
   font-family: ui-monospace, monospace;
-  font-size: 12px;
+  font-size: var(--text-size);
   overflow: hidden;
 }
 
@@ -31,7 +55,6 @@ body,
 
 #root {
   border-bottom: 1px solid rgb(255 255 255 / 5%);
-  background: linear-gradient(rgb(0 0 0 / 90%), rgb(5 2 20 / 85%));
 }
 
 .app {

--- a/examples/starter/styles.css
+++ b/examples/starter/styles.css
@@ -13,7 +13,7 @@
   --icon-color-light: LightSteelBlue; 
   --icon-color-dark: rgba(115 130 175 / 95%);  
 
-  --background-color-light: rgba(238 238 238, 90%);
+  --background-color-light: rgba(238 238 238 / 90%);
   --background-color-dark: linear-gradient(rgb(0 0 0 / 90%), rgb(5 2 20 / 85%));
 }
 


### PR DESCRIPTION
# ✨ Add automatic dark/light theme support via `prefers-color-scheme`
This update adds system theme synchronization to zebar using the CSS media query prefers-color-scheme.
Now, zebar will automatically adapt to your operating system's light or dark mode — no manual toggling required.

## 🎨 What changed
- Replaced hardcoded colors with CSS variables.
- Introduced media queries for `prefers-color-scheme: light` and `prefers-color-scheme: dark`.
- Added new CSS variables for:
    - `--text-size`
    - `--icon-size`
    - Making it easier to adjust font and icon sizes independently.
- The interface now updates automatically with system theme changes.

## 🧠 Motivation
As a Windows 11 user with [auto dark mode](https://github.com/AutoDarkMode/Windows-Auto-Night-Mode?tab=readme-ov-file) based on sunset/sunrise, I’ve always found it frustrating that the default zebar preset didn’t follow the system theme.
This small but meaningful tweak makes zebar feel more native, more modern, and better integrated into the daily workflow.

Also, there was previously no convenient way to customize font or icons size. With the new variables, it's now a little bit easier to adjust the UI to our preferences.

## ✅ Compatibility
- Tested on Windows 11 with automatic theme switching.
- Since it uses a standard CSS media query, it should work seamlessly on macOS and most Linux desktop environments as well.

## 🔄 Related
This might be an alternative way to partly resolve #203.

## 📸 Demo
### Before (always dark mode)

https://github.com/user-attachments/assets/4abc8a68-8927-4191-8b42-4b2cff679d90


### After (auto light/dark)

https://github.com/user-attachments/assets/9a24f386-7d83-4cc6-a25f-6eeaa71964b4

---

Thanks for creating and maintaining glazewm & zebar 🙌
