### PR TITLE
fix: add missing `isPaused` to type definition of `GlazeWmOutput`

### DIFF
--- a/packages/client-api/src/providers/glazewm/glazewm-provider-types.ts
+++ b/packages/client-api/src/providers/glazewm/glazewm-provider-types.ts
@@ -76,6 +76,11 @@ export interface GlazeWmOutput {
   bindingModes: BindingModeConfig[];
 
   /**
+   * Whether GlazeWM is currently paused.
+   */
+  isPaused: boolean;
+
+  /**
    * Invokes a WM command (e.g. `"focus --workspace 1"`).
    *
    * @param command WM command to run (e.g. `"focus --workspace 1"`).


### PR DESCRIPTION
Duplicate of #204 by @nullgato 