### PR TITLE
fix: correct typo `transmitSpeed` in type definition of `NetworkInterface`

### DIFF
--- a/packages/client-api/src/providers/network/network-provider-types.ts
+++ b/packages/client-api/src/providers/network/network-provider-types.ts
@@ -30,7 +30,7 @@ export interface NetworkInterface {
   ipv4Addresses: string[];
   ipv6Addresses: string[];
   macAddress: string | null;
-  transmitSeed: number | null;
+  transmitSpeed: number | null;
   receiveSpeed: number | null;
   dnsServers: string[];
   isDefault: boolean;


### PR DESCRIPTION
Corrects a typo in the `transmitSpeed` property of the `NetworkInterface` type definition.