### PR TITLE
feat: add double-click support for systray icons

### DIFF
--- a/crates/systray-util/src/systray.rs
+++ b/crates/systray-util/src/systray.rs
@@ -14,9 +14,9 @@ use windows::Win32::{
     Shell::{NIN_POPUPCLOSE, NIN_POPUPOPEN, NIN_SELECT},
     WindowsAndMessaging::{
       AllowSetForegroundWindow, GetWindowThreadProcessId, IsWindow,
-      SendNotifyMessageW, WM_CONTEXTMENU, WM_LBUTTONDOWN, WM_LBUTTONUP,
-      WM_MBUTTONDOWN, WM_MBUTTONUP, WM_MOUSEMOVE, WM_RBUTTONDOWN,
-      WM_RBUTTONUP,
+      SendNotifyMessageW, WM_CONTEXTMENU, WM_LBUTTONDBLCLK,
+      WM_LBUTTONDOWN, WM_LBUTTONUP, WM_MBUTTONDOWN, WM_MBUTTONUP,
+      WM_MOUSEMOVE, WM_RBUTTONDOWN, WM_RBUTTONUP,
     },
   },
 };
@@ -209,6 +209,7 @@ pub enum SystrayIconAction {
   HoverLeave,
   HoverMove,
   LeftClick,
+  LeftDoubleClick,
   RightClick,
   MiddleClick,
 }
@@ -440,6 +441,7 @@ impl Systray {
     let is_mouse_click = matches!(
       action,
       SystrayIconAction::LeftClick
+        | SystrayIconAction::LeftDoubleClick
         | SystrayIconAction::RightClick
         | SystrayIconAction::MiddleClick
     );
@@ -461,6 +463,9 @@ impl Systray {
 
     let wm_messages = match action {
       SystrayIconAction::LeftClick => vec![WM_LBUTTONDOWN, WM_LBUTTONUP],
+      SystrayIconAction::LeftDoubleClick => {
+        vec![WM_LBUTTONDBLCLK, WM_LBUTTONUP]
+      }
       SystrayIconAction::RightClick => {
         vec![WM_RBUTTONDOWN, WM_RBUTTONUP]
       }
@@ -489,7 +494,9 @@ impl Systray {
       let v3_message = match action {
         SystrayIconAction::HoverEnter => NIN_POPUPOPEN,
         SystrayIconAction::HoverLeave => NIN_POPUPCLOSE,
-        SystrayIconAction::LeftClick => NIN_SELECT,
+        SystrayIconAction::LeftClick | SystrayIconAction::LeftDoubleClick => {
+          NIN_SELECT
+        }
         SystrayIconAction::RightClick => WM_CONTEXTMENU,
         _ => return Ok(()),
       };

--- a/packages/client-api/src/providers/systray/create-systray-provider.ts
+++ b/packages/client-api/src/providers/systray/create-systray-provider.ts
@@ -97,6 +97,15 @@ export function createSystrayProvider(
                 },
               });
             },
+            onLeftDoubleClick: (iconId: string) => {
+              return desktopCommands.callProviderFunction(configHash, {
+                type: 'systray',
+                function: {
+                  name: 'icon_left_double_click',
+                  args: { iconId },
+                },
+              });
+            },
             onRightClick: (iconId: string) => {
               return desktopCommands.callProviderFunction(configHash, {
                 type: 'systray',

--- a/packages/client-api/src/providers/systray/systray-provider-types.ts
+++ b/packages/client-api/src/providers/systray/systray-provider-types.ts
@@ -16,6 +16,7 @@ export interface SystrayOutput {
   onHoverMove: (iconId: string) => Promise<void>;
   onRightClick: (iconId: string) => Promise<void>;
   onLeftClick: (iconId: string) => Promise<void>;
+  onLeftDoubleClick: (iconId: string) => Promise<void>;
   onMiddleClick: (iconId: string) => Promise<void>;
 }
 

--- a/packages/desktop/src/providers/provider_function.rs
+++ b/packages/desktop/src/providers/provider_function.rs
@@ -52,6 +52,7 @@ pub enum SystrayFunction {
   IconHoverLeave(SystrayIconArgs),
   IconHoverMove(SystrayIconArgs),
   IconLeftClick(SystrayIconArgs),
+  IconLeftDoubleClick(SystrayIconArgs),
   IconRightClick(SystrayIconArgs),
   IconMiddleClick(SystrayIconArgs),
 }

--- a/packages/desktop/src/providers/systray/systray_provider.rs
+++ b/packages/desktop/src/providers/systray/systray_provider.rs
@@ -85,6 +85,10 @@ impl SystrayProvider {
         &args.icon_id.parse()?,
         &SystrayIconAction::LeftClick,
       ),
+      SystrayFunction::IconLeftDoubleClick(args) => systray.send_action(
+        &args.icon_id.parse()?,
+        &SystrayIconAction::LeftDoubleClick,
+      ),
       SystrayFunction::IconRightClick(args) => systray.send_action(
         &args.icon_id.parse()?,
         &SystrayIconAction::RightClick,


### PR DESCRIPTION
The systray-util crate in the zebar project had no support for double-clicking a system tray icon. The existing SystrayIconAction enum only covered single left click, right click, middle click, and hover actions. This meant that applications relying on double-click behavior for their tray icons (which is common for actions like opening an application's main window) could not be triggered through the zebar systray provider.

To solve this, a LeftDoubleClick variant was added to the SystrayIconAction enum in the core systray-util crate. Its implementation sends the WM_LBUTTONDBLCLK and WM_LBUTTONUP Win32 messages to the target icon's window, which is the standard Windows message sequence for a double-click event. It also calls AllowSetForegroundWindow before sending the messages, matching the behavior of the other click actions, and sends NIN_SELECT as a follow-up notification for icons using version 3 or above of the shell notify API, consistent with how Windows Explorer handles double-clicks.

The change was then propagated through the full stack. An IconLeftDoubleClick variant was added to the SystrayFunction enum in the desktop provider layer, with a corresponding match arm in the systray provider's function handler to route it to the new action. On the TypeScript side, an onLeftDoubleClick callback was added to the SystrayOutput interface and wired up in the client provider to invoke the icon_left_double_click provider function via Tauri commands. This gives frontend widget authors a new onLeftDoubleClick(iconId) method they can bind to DOM double-click events.