### PR TITLE
fix: cache WLAN handle in network provider

### DIFF
--- a/packages/desktop/src/providers/network/network_provider.rs
+++ b/packages/desktop/src/providers/network/network_provider.rs
@@ -2,7 +2,7 @@ use serde::{Deserialize, Serialize};
 use sysinfo::Networks;
 
 use super::{
-  wifi_hotspot::{default_gateway_wifi, WifiHotstop},
+  wifi_hotspot::{WifiHotstop, WlanMonitor},
   InterfaceType, NetworkGateway, NetworkInterface, NetworkTraffic,
   NetworkTrafficMeasure,
 };
@@ -32,6 +32,7 @@ pub struct NetworkProvider {
   config: NetworkProviderConfig,
   common: CommonProviderState,
   netinfo: Networks,
+  wlan_monitor: Option<WlanMonitor>,
 }
 
 impl NetworkProvider {
@@ -43,6 +44,7 @@ impl NetworkProvider {
       config,
       common,
       netinfo: Networks::new_with_refreshed_list(),
+      wlan_monitor: WlanMonitor::new(),
     }
   }
 
@@ -60,6 +62,9 @@ impl NetworkProvider {
     let transmitted_per_sec =
       transmitted / self.config.refresh_interval * 1000;
 
+    let wifi_info =
+      self.wlan_monitor.as_ref().and_then(|m| m.query().ok());
+
     Ok(NetworkOutput {
       default_interface: default_interface
         .as_ref()
@@ -67,9 +72,7 @@ impl NetworkProvider {
       default_gateway: default_interface
         .and_then(|interface| interface.gateway)
         .and_then(|gateway| {
-          default_gateway_wifi()
-            .map(|wifi| Self::transform_gateway(&gateway, wifi))
-            .ok()
+          wifi_info.map(|wifi| Self::transform_gateway(&gateway, wifi))
         }),
       interfaces: interfaces
         .iter()

--- a/packages/desktop/src/providers/network/wifi_hotspot.rs
+++ b/packages/desktop/src/providers/network/wifi_hotspot.rs
@@ -17,7 +17,6 @@ pub struct WifiHotstop {
   pub signal_strength: Option<u32>,
 }
 
-#[derive(Debug)]
 #[cfg(target_os = "windows")]
 struct WlanHandle(HANDLE);
 
@@ -30,84 +29,108 @@ impl Drop for WlanHandle {
   }
 }
 
-/// Gets wifi ssid and signal strength using winapi
-pub fn default_gateway_wifi() -> anyhow::Result<WifiHotstop> {
-  #[cfg(not(target_os = "windows"))]
-  {
-    Ok(WifiHotstop {
-      ssid: None,
-      signal_strength: None,
-    })
+/// Cached WLAN handle for querying WiFi connection info
+/// without reopening the handle on every poll.
+#[cfg(target_os = "windows")]
+pub struct WlanMonitor {
+  handle: WlanHandle,
+}
+
+#[cfg(not(target_os = "windows"))]
+pub struct WlanMonitor;
+
+impl WlanMonitor {
+  pub fn new() -> Option<Self> {
+    #[cfg(target_os = "windows")]
+    {
+      let mut pdw_negotiated_version = 0;
+      let mut wlan_handle = WlanHandle(INVALID_HANDLE_VALUE);
+
+      WIN32_ERROR(unsafe {
+        WlanOpenHandle(
+          2,
+          None,
+          &mut pdw_negotiated_version,
+          &mut wlan_handle.0,
+        )
+      })
+      .ok()
+      .ok()?;
+
+      Some(WlanMonitor {
+        handle: wlan_handle,
+      })
+    }
+
+    #[cfg(not(target_os = "windows"))]
+    Some(WlanMonitor)
   }
-  #[cfg(target_os = "windows")]
-  {
-    let mut pdw_negotiated_version = 0;
-    let mut wlan_handle = WlanHandle(INVALID_HANDLE_VALUE);
 
-    WIN32_ERROR(unsafe {
-      WlanOpenHandle(
-        2,
-        None,
-        &mut pdw_negotiated_version,
-        &mut wlan_handle.0,
-      )
-    })
-    .ok()
-    .context("Failed to open Wlan handle")?;
+  pub fn query(&self) -> anyhow::Result<WifiHotstop> {
+    #[cfg(not(target_os = "windows"))]
+    {
+      Ok(WifiHotstop {
+        ssid: None,
+        signal_strength: None,
+      })
+    }
 
-    let mut wlan_interface_info_list = std::ptr::null_mut();
-    WIN32_ERROR(unsafe {
-      WlanEnumInterfaces(
-        wlan_handle.0,
-        None,
-        &mut wlan_interface_info_list,
-      )
-    })
-    .ok()
-    .context("Failed to get Wlan interfaces")?;
+    #[cfg(target_os = "windows")]
+    {
+      let mut wlan_interface_info_list = std::ptr::null_mut();
+      WIN32_ERROR(unsafe {
+        WlanEnumInterfaces(
+          self.handle.0,
+          None,
+          &mut wlan_interface_info_list,
+        )
+      })
+      .ok()
+      .context("Failed to get Wlan interfaces")?;
 
-    let guid = (unsafe { *wlan_interface_info_list }).InterfaceInfo[0]
-      .InterfaceGuid;
-    unsafe { WlanFreeMemory(wlan_interface_info_list as *mut c_void) };
+      let guid = (unsafe { *wlan_interface_info_list }).InterfaceInfo[0]
+        .InterfaceGuid;
+      unsafe { WlanFreeMemory(wlan_interface_info_list as *mut c_void) };
 
-    let mut data_size = 0;
-    let mut pdata = std::ptr::null_mut();
+      let mut data_size = 0;
+      let mut pdata = std::ptr::null_mut();
 
-    WIN32_ERROR(unsafe {
-      WlanQueryInterface(
-        wlan_handle.0,
-        &guid,
-        wlan_intf_opcode_current_connection,
-        None,
-        &mut data_size,
-        &mut pdata,
-        None,
-      )
-    })
-    .ok()
-    .context("Failed to get connected Wlan interface")?;
+      WIN32_ERROR(unsafe {
+        WlanQueryInterface(
+          self.handle.0,
+          &guid,
+          wlan_intf_opcode_current_connection,
+          None,
+          &mut data_size,
+          &mut pdata,
+          None,
+        )
+      })
+      .ok()
+      .context("Failed to get connected Wlan interface")?;
 
-    let wlan_connection_atributes =
-      pdata as *mut WLAN_CONNECTION_ATTRIBUTES;
-    let atributes =
-      unsafe { *wlan_connection_atributes }.wlanAssociationAttributes;
+      let wlan_connection_atributes =
+        pdata as *mut WLAN_CONNECTION_ATTRIBUTES;
+      let atributes =
+        unsafe { *wlan_connection_atributes }.wlanAssociationAttributes;
 
-    unsafe { WlanFreeMemory(pdata) };
+      unsafe { WlanFreeMemory(pdata) };
 
-    // needed to remove leading zeros in array
-    let ssid_arr = atributes.dot11Ssid.ucSSID;
-    let mut ssid_vec = ssid_arr
-      .into_iter()
-      .rev()
-      .skip_while(|&byte| byte == 0)
-      .collect::<Vec<_>>();
-    ssid_vec.reverse();
-    let ssid =
-      String::from_utf8(ssid_vec).context("Incorrectly formatted ssid")?;
+      // needed to remove leading zeros in array
+      let ssid_arr = atributes.dot11Ssid.ucSSID;
+      let mut ssid_vec = ssid_arr
+        .into_iter()
+        .rev()
+        .skip_while(|&byte| byte == 0)
+        .collect::<Vec<_>>();
+      ssid_vec.reverse();
+      let ssid = String::from_utf8(ssid_vec)
+        .context("Incorrectly formatted ssid")?;
 
-    Ok(WifiHotstop {
-      ssid: Some(ssid),
-      signal_strength: Some(atributes.wlanSignalQuality),
-    })
+      Ok(WifiHotstop {
+        ssid: Some(ssid),
+        signal_strength: Some(atributes.wlanSignalQuality),
+      })
+    }
   }
 }


### PR DESCRIPTION
## Summary

- Cache the `WlanOpenHandle` in a `WlanMonitor` struct that opens it once and reuses it for all subsequent WiFi SSID/signal queries
- Previously, `WlanOpenHandle`/`WlanCloseHandle` was called on every network poll interval, creating and destroying OS WLAN handles thousands of times per hour

Split out from #262 per maintainer request.

Related: #261

## Context

The repeated WLAN handle cycling causes kernel-side resource fragmentation in the Windows WiFi subsystem over extended uptime (12+ hours), contributing to progressive system stutter.

## Test plan

- [x] Verify WiFi SSID and signal strength still reported correctly
- [x] Run Zebar with network provider for extended period, confirm no degradation

🤖 Generated with [Claude Code](https://claude.com/claude-code)