### PR TITLE
fix: avoid setting window level on macOS to `kCGBackstopMenuLevel`

### DIFF
--- a/packages/desktop/src/commands.rs
+++ b/packages/desktop/src/commands.rs
@@ -3,7 +3,7 @@ use std::{collections::HashMap, sync::Arc};
 use tauri::{State, Window};
 
 #[cfg(target_os = "macos")]
-use crate::common::macos::{CustomWindowLevel, WindowExtMacOs};
+use crate::common::macos::WindowExtMacOs;
 #[cfg(target_os = "windows")]
 use crate::common::windows::WindowExtWindows;
 use crate::{
@@ -245,7 +245,7 @@ pub async fn stop_all_preview_widgets(
 #[tauri::command]
 pub fn set_always_on_top(window: Window) -> anyhow::Result<(), String> {
   #[cfg(target_os = "macos")]
-  let res = window.set_level(CustomWindowLevel::AboveMenuBar);
+  let res = window.set_above_menu_bar();
 
   #[cfg(not(target_os = "macos"))]
   let res = window.set_always_on_top(true);

--- a/packages/desktop/src/common/macos/window_ext_macos.rs
+++ b/packages/desktop/src/common/macos/window_ext_macos.rs
@@ -5,28 +5,17 @@ use cocoa::{
 };
 use tauri::{Runtime, Window};
 
-pub enum CustomWindowLevel {
-  AboveMenuBar,
-  // TODO: Use this for bottom-most windows.
-  Backstop,
-}
-
 pub trait WindowExtMacOs {
-  fn set_level(&self, level: CustomWindowLevel) -> anyhow::Result<()>;
+  fn set_above_menu_bar(&self) -> anyhow::Result<()>;
 }
 
 impl<R: Runtime> WindowExtMacOs for Window<R> {
-  fn set_level(&self, level: CustomWindowLevel) -> anyhow::Result<()> {
+  fn set_above_menu_bar(&self) -> anyhow::Result<()> {
     let ns_win =
       self.ns_window().context("Failed to get window handle.")? as id;
 
-    let level = match level {
-      CustomWindowLevel::AboveMenuBar => NSMainMenuWindowLevel as i64 + 1,
-      CustomWindowLevel::Backstop => -20,
-    };
-
     unsafe {
-      ns_win.setLevel_(level);
+      ns_win.setLevel_(NSMainMenuWindowLevel as i64 + 1);
     }
 
     Ok(())

--- a/packages/desktop/src/widget_factory.rs
+++ b/packages/desktop/src/widget_factory.rs
@@ -20,7 +20,7 @@ use tokio::{
 use tracing::{error, info};
 
 #[cfg(target_os = "macos")]
-use crate::common::macos::{CustomWindowLevel, WindowExtMacOs};
+use crate::common::macos::WindowExtMacOs;
 #[cfg(target_os = "windows")]
 use crate::common::windows::{remove_app_bar, WindowExtWindows};
 use crate::{
@@ -343,6 +343,9 @@ impl WidgetFactory {
         )?,
       };
 
+      // Adjust the z-order of the window.
+      Self::set_z_order(&window, &widget_config.z_order, placement)?;
+
       info!("Positioning widget to {:?} {:?}", size, position);
       let _ = window.set_size(size);
       let _ = window.set_position(position);
@@ -354,9 +357,6 @@ impl WidgetFactory {
         let _ = window.set_size(size);
         let _ = window.set_position(position);
       }
-
-      // Adjust the z-order of the window.
-      Self::set_z_order(&window, &widget_config.z_order, placement)?;
 
       // On Windows, Tauri's `skip_taskbar` option isn't 100% reliable,
       // so we also set the window as a tool window.
@@ -396,7 +396,7 @@ impl WidgetFactory {
     placement: &WidgetPlacement,
   ) -> anyhow::Result<()> {
     // On macOS, the window level must be set above the menu bar or at the
-    // backstop level to prevent it from being shifted down beneath the
+    // bottom-most level to prevent it from being shifted down beneath the
     // menu bar.
     #[cfg(target_os = "macos")]
     {
@@ -404,15 +404,11 @@ impl WidgetFactory {
         && placement.dock_to_edge.edge == Some(DockEdge::Top)
       {
         return if *z_order == ZOrder::TopMost {
-          window
-            .as_ref()
-            .window()
-            .set_level(CustomWindowLevel::AboveMenuBar)
+          window.as_ref().window().set_above_menu_bar()
         } else {
           window
-            .as_ref()
-            .window()
-            .set_level(CustomWindowLevel::Backstop)
+            .set_always_on_bottom(true)
+            .map_err(anyhow::Error::from)
         };
       }
     }
@@ -431,10 +427,7 @@ impl WidgetFactory {
         // to truly be always on top.
         #[cfg(target_os = "macos")]
         {
-          window
-            .as_ref()
-            .window()
-            .set_level(CustomWindowLevel::AboveMenuBar)
+          window.as_ref().window().set_above_menu_bar()
         }
       }
       ZOrder::BottomMost => window


### PR DESCRIPTION
Causes a crash when multiple widget windows with `kCGBackstopMenuLevel` are set to the same coordinates.