### PR TITLE
fix: recover widgets lost during monitor connect/disconnect on macOS

### DIFF
--- a/packages/desktop/src/main.rs
+++ b/packages/desktop/src/main.rs
@@ -2,7 +2,7 @@
 #![cfg_attr(not(debug_assertions), windows_subsystem = "windows")]
 #![feature(iterator_try_collect)]
 
-use std::{env, path::Path, sync::Arc};
+use std::{env, path::Path, sync::Arc, time::Duration};
 
 use anyhow::Context;
 use clap::Parser;
@@ -11,7 +11,7 @@ use tauri::{
   Manager, RunEvent, WebviewUrl, WebviewWindowBuilder,
 };
 use tokio::{sync::mpsc, task};
-use tracing::{error, info, Level};
+use tracing::{error, info, warn, Level};
 use tracing_subscriber::{
   fmt::{self, writer::MakeWriterExt},
   layer::SubscriberExt,
@@ -305,7 +305,41 @@ fn listen_events(
         },
         Ok(_) = monitors_change_rx.recv() => {
           info!("Monitors changed.");
-          widget_factory.relaunch_all().await
+
+          if let Err(err) = widget_factory.relaunch_all().await {
+            error!("Failed to relaunch widgets on monitor change: {:?}", err);
+          }
+
+          // Safety net: if all widgets were lost during relaunch (e.g.
+          // monitors were transiently unavailable), retry from startup
+          // config with backoff.
+          if widget_factory.states().await.is_empty() {
+            let startup_configs = app_settings.startup_configs().await;
+
+            if !startup_configs.is_empty() {
+              warn!(
+                "No widgets running after monitor change, \
+                 attempting recovery from startup config."
+              );
+
+              for attempt in 1..=3u64 {
+                tokio::time::sleep(
+                  Duration::from_millis(attempt * 500)
+                ).await;
+
+                if let Err(err) = widget_factory.startup().await {
+                  error!("Widget recovery attempt {} failed: {:?}", attempt, err);
+                }
+
+                if !widget_factory.states().await.is_empty() {
+                  info!("Widget recovery successful on attempt {}.", attempt);
+                  break;
+                }
+              }
+            }
+          }
+
+          Ok(())
         },
         Ok((pack_id, changed_config)) = widget_configs_change_rx.recv() => {
           info!("Widget config changed.");

--- a/packages/desktop/src/monitor_state.rs
+++ b/packages/desktop/src/monitor_state.rs
@@ -6,7 +6,7 @@ use tokio::{
   sync::{broadcast, RwLock},
   task,
 };
-use tracing::info;
+use tracing::{info, warn};
 
 use crate::widget_pack::MonitorSelection;
 
@@ -76,6 +76,19 @@ impl MonitorState {
           let current_monitors = monitors.read().await;
           *current_monitors != new_monitors
         };
+
+        // Skip broadcasting when the monitor list is empty. During
+        // macOS display reconfiguration, `available_monitors()` can
+        // transiently return an empty list. Broadcasting this would
+        // trigger a relaunch that creates zero windows, permanently
+        // losing all widget state.
+        if new_monitors.is_empty() {
+          warn!(
+            "available_monitors() returned empty list, \
+             skipping update (likely transient during display change)."
+          );
+          continue;
+        }
 
         if should_update {
           info!("Detected change in monitors.");

--- a/packages/desktop/src/widget_factory.rs
+++ b/packages/desktop/src/widget_factory.rs
@@ -17,7 +17,7 @@ use tokio::{
   sync::{broadcast, Mutex},
   task,
 };
-use tracing::{error, info};
+use tracing::{error, info, warn};
 
 #[cfg(target_os = "macos")]
 use crate::common::macos::WindowExtMacOs;
@@ -268,7 +268,17 @@ impl WidgetFactory {
       }
     };
 
-    for coordinates in self.widget_coordinates(placement).await {
+    let all_coordinates = self.widget_coordinates(placement).await;
+
+    if all_coordinates.is_empty() {
+      warn!(
+        "No monitors matched selection {:?} for widget '{}'. \
+         Widget will not be created.",
+        placement.monitor_selection, widget_name
+      );
+    }
+
+    for coordinates in all_coordinates {
       let new_count =
         self.widget_count.fetch_add(1, Ordering::Relaxed) + 1;
 
@@ -824,6 +834,8 @@ impl WidgetFactory {
         .collect::<Vec<_>>()
     };
 
+    let mut errors = vec![];
+
     for widget_state in &changed_states {
       info!(
         "Relaunching widget {} from {} (#{}).",
@@ -832,17 +844,28 @@ impl WidgetFactory {
 
       let _ = self.stop_by_id(&widget_state.id);
 
-      self
+      if let Err(err) = self
         .start_widget_by_id(
           &widget_state.pack_id,
           &widget_state.name,
           &widget_state.open_options,
           false,
         )
-        .await?;
+        .await
+      {
+        error!(
+          "Failed to relaunch widget {} from {}: {:?}",
+          widget_state.name, widget_state.pack_id, err
+        );
+        errors.push(err);
+      }
     }
 
-    Ok(())
+    if let Some(first_err) = errors.into_iter().next() {
+      Err(first_err)
+    } else {
+      Ok(())
+    }
   }
 
   /// Relaunches widgets with the given config paths.


### PR DESCRIPTION
## Summary

Fixes a bug where Zebar's bar silently disappears when connecting/disconnecting external monitors on macOS while the process and tray icon remain alive.

## Problem

During macOS display reconfiguration, Tauri's `available_monitors()` can transiently return an empty or partial list. The existing code path:

1. **`relaunch_all`** removes all widget states from the HashMap *before* attempting recreation
2. **`widget_coordinates`** returns an empty `Vec` when no monitors match → the creation loop runs zero iterations → returns `Ok(())`
3. Widget state is permanently lost — no error logged, no recovery attempted
4. Additionally, **`?` operator** in the per-widget relaunch loop bails on the first failure, skipping all remaining widgets whose states were already deleted

Result: process alive (tray icon visible), zero widget windows, empty error log.

## Fix

Three layered defenses:

- **Skip empty monitor broadcasts** (`monitor_state.rs`): When `available_monitors()` returns an empty list during display transition, skip the update to prevent premature relaunches with zero monitors
- **Per-widget error resilience** (`widget_factory.rs`): Collect errors instead of bailing on first failure, so one widget's error doesn't prevent siblings from relaunching. Also adds `warn!` when no monitors match a widget's selection
- **Startup recovery with backoff** (`main.rs`): After a monitor change relaunch, if `widget_states` is empty but startup configs exist, retry `startup()` with exponential backoff (500ms/1000ms/1500ms)

## Test plan

- [x] Confirm bar disappears on monitor disconnect (before fix)
- [ ] Verify bar recovers after monitor disconnect/reconnect (after fix)
- [ ] Verify normal startup and manual widget open/close still work
- [ ] Verify multi-monitor setup creates widgets on all monitors