### PR TITLE
feat: add isNextEnabled and isPreviousEnabled to MediaSession

### DIFF
--- a/README.md
+++ b/README.md
@@ -374,6 +374,8 @@ No config options.
 | `position` | Timestamp (in seconds) of current playback position.      | `number` |
 | `isPlaying` | Whether the media session is currently playing.      | `boolean` |
 | `isCurrentSession` | Whether this is the currently active session (i.e. `currentSession`).      | `boolean` |
+| `isNextEnabled` | Whether the media session can be skipped. | `boolean` |
+| `isPreviousEnabled` | Whether the media session can be rewound | `boolean` |
 
 #### `MediaControlOptions`
 

--- a/packages/client-api/src/providers/media/media-provider-types.ts
+++ b/packages/client-api/src/providers/media/media-provider-types.ts
@@ -31,6 +31,8 @@ export interface MediaSession {
   endTime: number;
   position: number;
   isPlaying: boolean;
+  isNextEnabled: boolean;
+  isPreviousEnabled: boolean;
   isCurrentSession: boolean;
 }
 

--- a/packages/desktop/src/providers/media/media_provider.rs
+++ b/packages/desktop/src/providers/media/media_provider.rs
@@ -45,6 +45,8 @@ pub struct MediaSession {
   pub end_time: u64,
   pub position: u64,
   pub is_playing: bool,
+  pub is_next_enabled: bool,
+  pub is_previous_enabled: bool,
   pub is_current_session: bool,
 }
 
@@ -61,6 +63,8 @@ impl Default for MediaSession {
       end_time: 0,
       position: 0,
       is_playing: false,
+      is_next_enabled: false,
+      is_previous_enabled: false,
       is_current_session: false,
     }
   }
@@ -536,6 +540,10 @@ impl MediaProvider {
 
     session_output.is_playing =
       info.PlaybackStatus()? == GsmtcPlaybackStatus::Playing;
+
+    let controls = info.Controls()?;
+    session_output.is_next_enabled = controls.IsNextEnabled()?;
+    session_output.is_previous_enabled = controls.IsPreviousEnabled()?;
 
     Ok(())
   }


### PR DESCRIPTION
## Summary
- Closes #188
- Added `isNextEnabled` and `isPreviousEnabled` boolean fields to `MediaSession`
- Extracts values from Windows `GlobalSystemMediaTransportControlsSessionPlaybackControls` API
## Motivation
Not all playback sessions support skip next/previous. Users need this information to conditionally render skip buttons in their UI.
## Changes
- `packages/desktop/src/providers/media/media_provider.rs`: Added fields to `MediaSession` struct and updated `update_playback_info()` to populate them
- `packages/client-api/src/providers/media/media-provider-types.ts`: Added TypeScript type definitions for the new fields
## Testing
Tested with Spotify & Youtube playing - fields correctly reflect whether next/previous controls are available.